### PR TITLE
fix the testing report email sending problem

### DIFF
--- a/TestRunner/HTMLTestRunner.py
+++ b/TestRunner/HTMLTestRunner.py
@@ -589,9 +589,8 @@ class SMTP(object):
             att["Content-Disposition"] = 'attachment; filename="{}"'.format(att_name)
             msg.attach(att)
 
-        smtp = smtplib.SMTP()
         try:
-            smtp.connect(self.host)
+            smtp = smtplib.SMTP_SSL(self.host, self.port)
             smtp.login(self.user, self.password)
             smtp.sendmail(self.user, to, msg.as_string())
             print(" 📧 Email sent successfully!!")

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -51,5 +51,7 @@ if __name__ == '__main__':
         )
         runner.run(suit)
     # 发邮件功能
+    # 使用126邮箱发送时password应为授权码而非用户密码，须在邮箱客户端设置开启授权码
+    # 使用gmail邮箱发送时password为用户密码，须在gmail客户端开启安全性较低的应用的访问权限
     smtp = SMTP(user="user@126.com", password="123", host="smtp.126.com")
     smtp.sender(to="user@126.com", attachments=report)


### PR DESCRIPTION
When using the original SMTP.connect to send testing report emails, it will encounter smtplib.SMTPServerDisconnected bugs. Using SMTP_SSL and specifying the host and port can help to fix the problem. Gmail and 126 mail are all tested to be compatible to this change. Notice that currently to use 126 mail client to send emails you should set authorization code as password instead of your login password. For Gmail there is no need to set authorization code but you should open the [Control access to less secure apps](https://support.google.com/a/answer/6260879) on your Google Account.