### PR TITLE
fix the problem that the chart overlap with results when scaling down web page

### DIFF
--- a/TestRunner/html/heading.html
+++ b/TestRunner/html/heading.html
@@ -10,7 +10,7 @@
     </div>
 </nav>
 
-<div class="container-fluid mm-active" style="padding-left: 35px;padding-right: 35px; padding-bottom:100px;">
+<div id="parentContainer" class="container-fluid mm-active" style="padding-left: 35px;padding-right: 35px;">
     <div style="height: 260px; margin-top: 20px;">
         
         <div class="row" style="margin-left: 0px; margin-right: 0px;">

--- a/TestRunner/html/stylesheet.html
+++ b/TestRunner/html/stylesheet.html
@@ -213,4 +213,16 @@
         position: fixed;
         bottom: 0;
     }
+    
+    @media screen and (max-width:1000px){
+        #parentContainer{
+            padding-bottom:300px
+        };
+    }
+
+    @media screen and (min-width:1000px){
+        #parentContainer{
+            padding-bottom:100px
+        };
+    }
 </style>


### PR DESCRIPTION
I use the responsive way to make sure that whenever scaling down or zoom in our zoom out the web page, the testing chart never overlaps with the result board.