### PR TITLE
fix the skip cases dismatch bug

### DIFF
--- a/TestRunner/HTMLTestRunner.py
+++ b/TestRunner/HTMLTestRunner.py
@@ -365,7 +365,7 @@ class HTMLTestRunner(TemplateMixing):
         RunResult.passed = result.success_count
         RunResult.failed = result.failure_count
         RunResult.errors = result.error_count
-        RunResult.Skiped = result.skip_count
+        RunResult.skiped = result.skip_count
         if result.success_count:
             status.append('Passed:%s' % result.success_count)
         if result.failure_count:


### PR DESCRIPTION
Hi, I find the place which causes the difference of skip cases in the testing report result.html and the email context.